### PR TITLE
Don't show helptip until graph is shown

### DIFF
--- a/digits/templates/models/images/classification/show.html
+++ b/digits/templates/models/images/classification/show.html
@@ -45,9 +45,10 @@
             <div id="combined-graph" class="combined-graph"
                 style="height:500px;width:100%;background:white;display:none;"></div>
             <span name="combined_graph_explanation"
-                            class="explanation-tooltip glyphicon glyphicon-question-sign"
+                            class="explanation-tooltip glyphicon glyphicon-question-sign combined-graph"
                             data-container="body"
                             title="Use bottom chart to select region of interest. Drag to pan left/right. Click outside of region to unselect."
+                            style="display:none;"
                                 ></span>
             <div class="pull-right combined-graph" style="display:none;">
                 <a class="btn btn-primary btn-sm" target="_blank"


### PR DESCRIPTION
The `show()` call already works on the `.combined-graph` class.
https://github.com/NVIDIA/DIGITS/blob/v2.0.0-rc2/digits/static/js/model-graphs.js#L3
